### PR TITLE
Make _CELLTYPE compatible with Python 3

### DIFF
--- a/pyjack.py
+++ b/pyjack.py
@@ -21,7 +21,10 @@ _WRAPPER_TYPES = (type(object.__init__), type(object().__init__),)
 def proxy0(data):
     def proxy1(): return data
     return proxy1
-_CELLTYPE = type(proxy0(None).func_closure[0])
+if _sys.version_info[0] < 3:
+    _CELLTYPE = type(proxy0(None).func_closure[0])
+else:
+    _CELLTYPE = type(proxy0(None).__closure__[0])
 
 
 class PyjackException(Exception): pass


### PR DESCRIPTION
I was using `replace_all_refs` in Python 3 (I checked 3.6, and 3.8) and it was choking on this line which I fixed as follows.